### PR TITLE
Add a hashing algorithm for passwords

### DIFF
--- a/src/sailor/access.lua
+++ b/src/sailor/access.lua
@@ -15,8 +15,27 @@ session.open(sailor.r)
 -- Comment to login through db (user model)
 local default = "demo"
 local default_pass = "demo"
+local salt = "sailorisawesome" -- uncomment to use unhashed passwords
 
 local INVALID = "Invalid username or password."
+
+-- Simple hashing algorithm for encrypting passworsd
+function access.hash(username, password)
+	local hash = username .. password
+	-- Check if bcrypt is embedded
+	if sailor.r.htpassword then
+		return sailor.r:htpassword(hash, 2, 100) -- Use bcrypt on pwd
+		
+	-- If not, fall back to sha1 hashing
+	else
+		if salt and sailor.r.sha1 then
+			for i = 1, 500 do
+				hash = sailor.r:sha1(salt .. hash)
+			end
+		end
+	end
+	return hash
+end
 
 
 function access.is_guest()
@@ -33,7 +52,10 @@ function access.login(username,password)
 	local id
 	if not default then
 		local User = sailor.model("user")
-		local u = User:find_by_attributes({username=username,password=password})
+		local u = User:find_by_attributes{
+			username=username,
+			password=access.hash(username, password)
+			}
 		if not u then
 			return false, INVALID
 		end


### PR DESCRIPTION
Salting and hashing passwords is essential for security.
First, try bcrypt if available, and fall back to sha1 hashing.
This will need to be added to account creation as well, so passwords written to the DB gets salted+hashed
