### PR TITLE
Fixes sailorproject docs link when create application

### DIFF
--- a/src/sailor/demo-app/views/main/index.lp
+++ b/src/sailor/demo-app/views/main/index.lp
@@ -2,4 +2,4 @@
 	<h1>Welcome to your first Sailor application</h1>
 </div>
 <p class="lead">This is the default view file, you will find it under <code>/views/main/index.lp</code>.
-It is rendered by a controller, you will find it under <code>/controllers/main.lua</code>. This layout is provided by <a href="http://getbootstrap.com/">Twitter Bootstrap</a>, an open source front-end framework. You can use this layout as is, modify it, or get new layouts and place them under <code>/layouts/</code>. Further documenation of Sailor MVC can be found <a href="http://sailorproject.org/?r=site/doc">here.</a></p>
+It is rendered by a controller, you will find it under <code>/controllers/main.lua</code>. This layout is provided by <a href="http://getbootstrap.com/">Twitter Bootstrap</a>, an open source front-end framework. You can use this layout as is, modify it, or get new layouts and place them under <code>/layouts/</code>. Further documenation of Sailor MVC can be found <a href="http://sailorproject.org/?r=docs">here.</a></p>

--- a/test/dev-app/views/main/index.lp
+++ b/test/dev-app/views/main/index.lp
@@ -2,4 +2,4 @@
 	<h1>Welcome to your first Sailor application</h1>
 </div>
 <p class="lead">This is the default view file, you will find it under <code>/views/main/index.lp</code>.
-It is rendered by a controller, you will find it under <code>/controllers/main.lua</code>. This layout is provided by <a href="http://getbootstrap.com/">Twitter Bootstrap</a>, an open source front-end framework. You can use this layout as is, modify it, or get new layouts and place them under <code>/layouts/</code>. Further documenation of Sailor MVC can be found <a href="http://sailorproject.org/?r=site/doc">here.</a></p>
+It is rendered by a controller, you will find it under <code>/controllers/main.lua</code>. This layout is provided by <a href="http://getbootstrap.com/">Twitter Bootstrap</a>, an open source front-end framework. You can use this layout as is, modify it, or get new layouts and place them under <code>/layouts/</code>. Further documenation of Sailor MVC can be found <a href="http://sailorproject.org/?r=docs">here.</a></p>


### PR DESCRIPTION
This is not a very important issue but it is interesting to have updated this link for beginners, like me :), to have a quick access to the documentation after creating the template application.
