### PR TITLE
chore(coverage): Fix file filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,9 @@ script:
   - if [ "$SERVER" == "openresty" ]; then sailor test --resty; fi
 
 after_success:
-  - luacov-coveralls -e $TRAVIS_BUILD_DIR/lua_install
+  - mv luacov.stats.out ../..
+  - cd ../..
+  - luacov-coveralls -c test/dev-app/.luacov
 
 notifications:
   email:

--- a/test/dev-app/.luacov
+++ b/test/dev-app/.luacov
@@ -1,0 +1,12 @@
+return {
+   modules = {
+      latclient = "src/latclient.lua",
+      ['latclient.*'] = "src",
+      remy = "src/remy.lua",
+      ['remy.*'] = "src",
+      sailor = "src/sailor.lua",
+      ['sailor.*'] = "src",
+      ['sailor.db.*'] = "src",
+      ['web_utils.*'] = "src"
+   }
+}


### PR DESCRIPTION
Currently coverage is low because all dependencies are included in the report. Add .luacov config leaving coverage related to sailor modules.