### PR TITLE
Changed location for 'Lua For Windows'

### DIFF
--- a/docs/INSTALL_WIN.md
+++ b/docs/INSTALL_WIN.md
@@ -4,7 +4,7 @@
 
 First, download and install Lua for Windows. You can get it from:
 
-<https://code.google.com/p/luaforwindows/>
+<https://github.com/rjpcomputing/luaforwindows>
 
 Copy the files in the `src` directory of this repository to C:/Program Files/Lua/5.1/lua/
 


### PR DESCRIPTION
The "Lua for Windows" package changed its home from Google Code to GitHub. This pull request simply updates the URL in the docs to the new one.