### PR TITLE
CLI refactor to use argparse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
 
 script:
   - cd test/dev-app
-  - if [ "$SERVER" != "openresty" ]; then sailor test --verbose --coverage; fi
+  - if [ "$SERVER" != "openresty" ]; then sailor test -- --verbose --coverage; fi
   - if [ "$SERVER" == "openresty" ]; then sailor test --resty; fi
 
 after_success:

--- a/rockspecs/sailor-current-1.rockspec
+++ b/rockspecs/sailor-current-1.rockspec
@@ -25,6 +25,8 @@ dependencies = {
    'remy >= 0.2',
    'latclient >= 0.4',
    'dkjson ~> 2.5',
+   'argparse',
+   'ansicolors'
 }
 build = {
    type = "builtin",

--- a/sailor
+++ b/sailor
@@ -40,7 +40,7 @@ end
 local function create(args, _)
 	local name = string.gsub(args.name:lower(),' ','_')
 	local current_dir = lfs.currentdir()
-	local destiny = arg[3] or current_dir
+	local destiny = args.path or current_dir
 
 	local sailor_path = get_sailor_path(current_dir)
 
@@ -61,7 +61,7 @@ local function create(args, _)
 	src = conf:read("*a")
 	conf:close()
 	conf = assert(io.open (new_app.."/conf/conf.lua" , "w"))
-	src = string.gsub(src,"Sailor! A Lua MVC Framework",arg[2])
+	src = string.gsub(src,"Sailor! A Lua MVC Framework", args.name)
 	conf:write(src)
 	conf:close()
 
@@ -92,35 +92,34 @@ local function test(args, _)
 end
 
 local function enable(args, _)
-	local name = 'sailor-'..arg[2]
+	local name = 'sailor-'..args.name
 	local current_dir = lfs.currentdir()
 	local sailor_path = get_sailor_path(current_dir)
 
 	assert(os.execute('luarocks install '..name))
 
-	local ext_app = sailor_path.."/sailor/"..arg[2].."/app"
+	local ext_app = sailor_path.."/sailor/"..name.."/app"
 	assert(os.execute("mkdir -p extensions"))
-	local err = assert(os.execute("cp -a '"..ext_app.."' extensions/"..arg[2]))
+	local err = assert(os.execute("cp -a '"..ext_app.."' extensions/"..name))
 	if err == 0 then
 		local index_file = assert(io.open ("index.lua" , "r"))
 		local src = index_file:read("*a")
 		index_file:close()
 
-		local package_path = "package.path =  base_dir..'extensions/"..arg[2].."/?.lua;'..package.path"
+		local package_path = "package.path =  base_dir..'extensions/"..name.."/?.lua;'..package.path"
 		src = string.gsub(src,"\nlocal sailor",package_path.."\n\nlocal sailor")
 		index_file = assert(io.open ("index.lua" , "w"))
 		index_file:write(src)
 		index_file:close()
 		print("New files:")
-		print("extensions/"..arg[2].."/*\n")
+		print("extensions/"..name.."/*\n")
 		print("Files modified:")
 		print("index.lua\n")
 		print("done!")
 	end
 end
 
-
-local parser = argparse("script", colors("%{blink yellow}Sailor commands"))
+local parser = argparse("script", colors("%{yellow}Sailor commands"))
     :name(string.match(arg[0], "/*(%w+)/*$"))
     :require_command(true)
 local create_cmd = parser:command("c create", "Generates web application in a directory."):action(create)

--- a/sailor
+++ b/sailor
@@ -55,11 +55,6 @@ local function get_sailor_path(current_dir)
 	return sailor_path
 end
 
-local function error()
-	print("\27[33mError generating sailor web app.\27[0m ")
-	print("Please report to developers.")
-end
-
 local function create()
 	local name = string.gsub(arg[2]:lower(),' ','_')
 	local current_dir = lfs.currentdir()

--- a/sailor
+++ b/sailor
@@ -9,28 +9,10 @@
 --------------------------------------------------------------------------------
 
 local lfs = require "lfs"
+--local inspect = require "inspect"
+local argparse = require "argparse"
+local colors = require "ansicolors"
 
-local function help()
-	print("\27[31mUsage: sailor command\27[0m \n")
-	print("Commands:")
-	print("  \27[31mcreate	Usage: sailor create NAME [PATH]\27[0m")
-	print("    		Generates web application in a directory.")
-	print("     NAME	The name of your application.")
-	print("     PATH	Optional. The path to where you wish your app to be created. \n\t\tIf not specified, the app will be created at the current dir.\n")
-	print("		\27[31mExample:\27[0m sailor create 'Hey Arnold' /var/www")
-	print("		This will create your web app under /var/www/hey_arnold.\n")
-	print("  \27[31mtest\t\tUsage: sailor test [FLAGS]\27[0m")
-	print("    		Will run the tests specified for an application.")
-	print("    		Must be called from the base dir of the application.")
-	print("     FLAGS	Optional. Flags for the Busted library.")
-	print("\n  \27[31menable\tUsage: sailor enable NAME\27[0m")
-	print("    		Will install an extension to Sailor and copy necessary files to your app.")
-	print("    		Must be called from the base dir of the application.")
-	print("     NAME	The name of the extension to be enabled.")
-	print("\nOptions:")
-	print("  --help	Shows help message.")
-	print("")
-end
 
 local function get_sailor_path(current_dir)
 	local sailor_path = ((debug.getinfo(1).source):match("^@?(.-)/sailor$"))
@@ -55,8 +37,8 @@ local function get_sailor_path(current_dir)
 	return sailor_path
 end
 
-local function create()
-	local name = string.gsub(arg[2]:lower(),' ','_')
+local function create(args, _)
+	local name = string.gsub(args.name:lower(),' ','_')
 	local current_dir = lfs.currentdir()
 	local destiny = arg[3] or current_dir
 
@@ -86,28 +68,30 @@ local function create()
 	print("done!")
 end
 
-local function test()
-	local resty = false
+local function test(args, _)
 	local flags = ''
 	for i=2,#arg do
-		if arg[i] == '--resty' then
-			resty = true
-		else
+		if not args.resty then
 			flags = flags..arg[i]..' '
 		end
 	end
 	local ok, code
-	if resty then
+	if args.resty then
 		ok, code = os.execute('resty tests/bootstrap_resty.lua')
 	else
 		ok, code = os.execute('busted --helper=tests/bootstrap.lua '..flags..'tests/unit/* tests/functional/*')
 	end
 
 	if type(ok) == "number" then return ok end -- Lua 5.1 just returns the status code
-	return ok and 0 or 1 -- don't care about actual value
+	exit_code = ok and 0 or 1 -- don't care about actual value
+
+    if exit_code and exit_code ~= 0 then
+    	-- exit code sometimes is > 255 and fails to be propagated
+    	os.exit(1, true)
+    end
 end
 
-local function enable()
+local function enable(args, _)
 	local name = 'sailor-'..arg[2]
 	local current_dir = lfs.currentdir()
 	local sailor_path = get_sailor_path(current_dir)
@@ -135,21 +119,21 @@ local function enable()
 	end
 end
 
-local function run()
 
-	if (arg[1] == 'create' or arg[1] == 'c') and arg[2] then
-		create()
-	elseif arg[1] == 'test' or arg[1] == 't' then
-		return test()
-	elseif arg[1] == 'enable' and arg[2] then
-		enable()
-	else
-		help()
-	end
-end
+local parser = argparse("script", colors("%{blink yellow}Sailor commands"))
+    :name(string.match(arg[0], "/*(%w+)/*$"))
+    :require_command(true)
+local create_cmd = parser:command("c create", "Generates web application in a directory."):action(create)
+    create_cmd:argument("name", "The name of your application.")
+    create_cmd:argument("path", "The path to where you wish your app to be created.")
+    :default(".")
+local test_cmd = parser:command("t test", "Will run the tests specified for an application. Must be called from the base dir of the application.")
+    :action(test)
+    -- Optional. Flags for the Busted library.")
+    test_cmd:flag("--resty", "Use", false)
+local enable_cmd = parser:command("e enable", "Will install an extension to Sailor and copy necessary files to your app. Must be called from the base dir of the application.")
+    :action(enable)
+    enable_cmd:argument("name", "The name of the extension to be enabled.")
 
-local exit_code = run()
-if exit_code and exit_code ~= 0 then
-	-- exit code sometimes is > 255 and fails to be propagated
-	os.exit(1, true)
-end
+local args = parser:parse()
+--print(inspect(args))

--- a/sailor
+++ b/sailor
@@ -69,17 +69,14 @@ local function create(args, _)
 end
 
 local function test(args, _)
-	local flags = ''
-	for i=2,#arg do
-		if not args.resty then
-			flags = flags..arg[i]..' '
-		end
-	end
 	local ok, code
+
+    flags = table.concat(args.EXTRA_FLAGS, " ")
+
 	if args.resty then
 		ok, code = os.execute('resty tests/bootstrap_resty.lua')
 	else
-		ok, code = os.execute('busted --helper=tests/bootstrap.lua '..flags..'tests/unit/* tests/functional/*')
+		ok, code = os.execute('busted --helper=tests/bootstrap.lua '..flags..' tests/unit/* tests/functional/*')
 	end
 
 	if type(ok) == "number" then return ok end -- Lua 5.1 just returns the status code
@@ -119,19 +116,26 @@ local function enable(args, _)
 	end
 end
 
-local parser = argparse("script", colors("%{yellow}Sailor commands"))
-    :name(string.match(arg[0], "/*(%w+)/*$"))
+local parser = argparse("script", colors("%{bright yellow}Sailor commands"))
+    :name(string.match(arg[0], "/*(%w+)/*$")) -- this file name, usually will be "sailor"
     :require_command(true)
 local create_cmd = parser:command("c create", "Generates web application in a directory."):action(create)
+    create_cmd:usage(colors("%{bright red}Usage: sailor create NAME [PATH]"))
     create_cmd:argument("name", "The name of your application.")
     create_cmd:argument("path", "The path to where you wish your app to be created.")
     :default(".")
+    create_cmd:epilog(colors([[
+        Example: %{bright red} sailor create 'Hey Arnold' /var/www %{reset}
+        This will create your web app under /var/www/hey_arnold.]]))
 local test_cmd = parser:command("t test", "Will run the tests specified for an application. Must be called from the base dir of the application.")
     :action(test)
+    test_cmd:usage(colors"%{bright red}Usage: sailor test [--resty] -- [EXTRA_FLAGS]")
     -- Optional. Flags for the Busted library.")
-    test_cmd:flag("--resty", "Use", false)
+    test_cmd:argument("EXTRA_FLAGS"):action("concat"):args("*")
+    test_cmd:flag("--resty", "Run the tests using the resty bootstrap", false)
 local enable_cmd = parser:command("e enable", "Will install an extension to Sailor and copy necessary files to your app. Must be called from the base dir of the application.")
     :action(enable)
+    enable_cmd:usage(colors("%{bright red}Usage: sailor enable NAME"))
     enable_cmd:argument("name", "The name of the extension to be enabled.")
 
 local args = parser:parse()

--- a/sailor
+++ b/sailor
@@ -138,5 +138,7 @@ local enable_cmd = parser:command("e enable", "Will install an extension to Sail
     enable_cmd:usage(colors("%{bright red}Usage: sailor enable NAME"))
     enable_cmd:argument("name", "The name of the extension to be enabled.")
 
+parser:usage(parser:get_help())
+
 local args = parser:parse()
 --print(inspect(args))


### PR DESCRIPTION
This PR is the refactor and use of the argparse part of issue #69. Add argparse itself as dependency and also ansicolors to improve the readability and maintainability of the help messages.

One thing to note is that the test command now need "--" before the arguments passed to busted.