### PR TITLE
docs: make Lua debian package version consistent

### DIFF
--- a/docs/INSTALL_LINUX.md
+++ b/docs/INSTALL_LINUX.md
@@ -5,7 +5,7 @@ Sailor is compatible with a variety of operating systems and webservers. On this
 
 If you don't have it already, install Lua. Sailor is compatible with both 5.1 and 5.2.
 
-    sudo apt-get install lua5.2
+    sudo apt-get install lua5.1
 
 ### Installing Apache 2.4
 


### PR DESCRIPTION
Make the Lua debian package version in CONTRIBUTING.md and
docs/INSTALL_LINUX.md the same for consistency.