### PR TITLE
style: have git ignore test database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .floo*
 *.swp
 *.swo
+test/db/


### PR DESCRIPTION
In the suggested developer environment setup described by CONTRIBUTING.md
a test database is created in test/db. After creating it, git status
continuously will show it as an untracked file, avoid this for all
developers following this setup.