### PR TITLE
Improve Nginx support

### DIFF
--- a/src/sailor.lua
+++ b/src/sailor.lua
@@ -52,11 +52,11 @@ end
 
 -- Stores the path of the application in sailor.path
 function sailor.set_application_path(r)
-    if r.uri and r.filename then
-        local filename = r.uri:match( "([^/]+)$") 
-        if filename then
-            sailor.path = r.filename:match("^@?(.-)/"..filename.."$")
-            if sailor.path ~= '.' then return end
+    if r.filename then
+        local new_path = r.filename:match("^@?(.*)/")
+        if new_path and new_path ~= "." then
+            sailor.path = new_path
+            return
         end
     end
     sailor.path = lfs.currentdir()

--- a/src/sailor/blank-app/conf/nginx.conf
+++ b/src/sailor/blank-app/conf/nginx.conf
@@ -19,31 +19,21 @@ http {
             index  index.lua index.lp;
         }
 
-        location ~ ^/[^.]+$ {
+        location ~ ^/[^\.]+$ {
             lua_need_request_body on;
-            lua_code_cache off;
-            content_by_lua_file index.lua;
-            rewrite_by_lua '
-                local utils = require "web_utils.utils"
-                local path = utils.split(ngx.var.uri,[[/]])
-                local args = {}
-                local start
+            lua_code_cache        on;
+            content_by_lua_file   index.lua;
+            index                 index.lp index.lua;
+            rewrite_by_lua_block  {
+                local conf = require "conf.conf"
+                if conf.sailor.friendly_urls then
+                    local args = ngx.req.get_uri_args()
+                    args[conf.sailor.route_parameter] = ngx.var.uri:sub(2)
 
-                if #path % 2 == 0 then 
-                    args[#args+1] = "r="..path[1]..[[/]]..path[2]
-                    start = 3
-                else
-                    args[#args+1] = "r="..path[1]
-                    start = 2
+                    ngx.req.set_uri_args(args)
+                    ngx.req.set_uri("/index.lua")
                 end
-
-                for i=start,#path,2 do
-                    args[#args+1] = path[i].."="..tostring(path[i+1])
-                end
-
-                ngx.req.set_uri_args(table.concat(args,"&"))
-                ngx.req.set_uri("/index.lua")
-            ';
+            }
         }
 
         location ~ \.(css|eot|js|json|gif|jpg|png|svg|ttf|woff)$ {


### PR DESCRIPTION
Connects to #72 
Connects to #48 
Fixes #42 

The new friendly URLs code didn't work at all, so I rewrote it. It now takes into account the settings defined in `conf.lua`, and also removes the other dependencies.

Also, the wrong `sailor.path` was being selected out of `r.filename` due to the use of `.-` instead of `.*`. A nice consequence of this change is that you don't need to know what the `r.uri` is, and so it has been removed from the expression.