### PR TITLE
fix(cli): Fix missing start-server.lua handling in start command

### DIFF
--- a/src/sailor/cli.lua
+++ b/src/sailor/cli.lua
@@ -109,7 +109,7 @@ function cli.gen_model(args)
 end
 
 function cli.start()
-	local ok, _ = xpcall(require "start-server")
+	local ok, _ = pcall(require, "start-server")
 	if not ok then
 		print("Start script not found. Please run this command from the root dir of your Sailor app.")
 		os.exit(1, true)


### PR DESCRIPTION
Don't call `require "start-server"` in unprotected mode,
actually pass `require` and `"start-server"` as arguments
to `pcall`. Use `pcall` instead of `xpcall` as no error handler is used.