### PR TITLE
chore(rockspec): add support for 5.4

### DIFF
--- a/rockspecs/sailor-current-1.rockspec
+++ b/rockspecs/sailor-current-1.rockspec
@@ -16,7 +16,6 @@ dependencies = {
    'datafile >= 0.1',
    'luafilesystem >= 1.6.2',
    'valua >= 0.2.2',
-   --'lbase64 >= 20120807',
    'cgilua >= 5.1.4',
    'xavante >= 2.3',
    'wsapi-xavante >= 1.6.1',

--- a/rockspecs/sailor-current-1.rockspec
+++ b/rockspecs/sailor-current-1.rockspec
@@ -12,11 +12,11 @@ description = {
    license = "MIT"
 }
 dependencies = {
-   "lua >= 5.1, < 5.4",
+   "lua >= 5.1, < 5.5",
    'datafile >= 0.1',
    'luafilesystem >= 1.6.2',
    'valua >= 0.2.2',
-   'lbase64 >= 20120807',
+   --'lbase64 >= 20120807',
    'cgilua >= 5.1.4',
    'xavante >= 2.3',
    'wsapi-xavante >= 1.6.1',


### PR DESCRIPTION
- Passed all tests in the test-app.
- Requires patched "valua" from https://github.com/sailorproject/valua/pull/21
- Requires patched "wsapi" from https://github.com/keplerproject/wsapi/pull/48
  - This is only required if using Xavante with CGILua 6.x (which is the current version)